### PR TITLE
Add xhr.setRequestHeader to allow for custom headers in requests

### DIFF
--- a/javascript/xhr.py
+++ b/javascript/xhr.py
@@ -72,6 +72,9 @@ class XMLHttpRequest(events.EventSourceMixin, v8.JSClass):
         self.readyState = self.OPENED
         self.triggerEvent("readystatechange")
 
+    def setRequestHeader(self, header, value):
+        self.__request.headers[header] = value
+
     def overrideMimeType(self, mimetype):
         self.__mime_override = mimetype
 


### PR DESCRIPTION
Was testing out on my apps and discovered that the `XMLHttpRequest` class didn't include setRequestHeader, which my apps all use, so I've added it to `XMLHttpRequest`.
