### PR TITLE
Fix string list serializer to match spec

### DIFF
--- a/timeline/attributes.py
+++ b/timeline/attributes.py
@@ -76,7 +76,7 @@ class TimelineAttributeSet(object):
     def _serialise_string_array(value, attribute_info):
         try:
             parts = '\x00'.join(value)
-            return struct.pack('<H%ssB' % len(parts), len(parts), parts.encode('utf-8'), 0x00)
+            return struct.pack('<%ss' % len(parts), parts.encode('utf-8'))
         except TypeError:
             return None
 


### PR DESCRIPTION
To match iOS and Android's implementation: String lists do not contain their length, and omit the last NULL byte.

Tested by inserting a weather pin containing a heading/paragraph pair.