### PR TITLE
PBL-24272 CloudPebble: Emulator does not work with Vagrant out of the box

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "PyV8"]
 	path = PyV8
-	url = git@github.com:pebble/pyv8-prebuilt.git
+	url = https://github.com/pebble/pyv8-prebuilt.git


### PR DESCRIPTION
The ssh URL is less likely to work when CloudPebble is being run inside a vagrant box. The easiest solution is just to stick to HTTPS URLs.