### PR TITLE
Make pypkjs platform-independent

### DIFF
--- a/pypkjs/runner/__init__.py
+++ b/pypkjs/runner/__init__.py
@@ -59,7 +59,8 @@ class Runner(object):
                 else:
                     src = z.open('pebble-js-app.js').read().decode('utf-8')
                 layouts = {}
-                for platform in ('aplite', 'basalt', 'chalk', 'diorite'):
+                platforms = [os.path.dirname(path) for path in z.namelist() if 'layouts.json' in path]
+                for platform in platforms:
                     try:
                         layouts[platform] = json.load(z.open('%s/layouts.json' % platform))
                     except (KeyError, ValueError):


### PR DESCRIPTION
Remove the explicit naming of platforms and instead consider any folder in a pbw with layouts.json a platform (for the purposes of loading a layouts.json file)