### PR TITLE
Improve SyntaxError logging

### DIFF
--- a/pypkjs/javascript/runtime.py
+++ b/pypkjs/javascript/runtime.py
@@ -67,6 +67,9 @@ class JSRuntime(object):
             logger.info("JS starting")
             try:
                 self.context.eval(src, filename)
+            except (v8.JSSyntaxError) as e:
+                self.log_output(e.hint(src))
+                self.log_output("JS failed.")
             except (v8.JSError, JSRuntimeException) as e:
                 self.log_output(e.stackTrace)
                 self.log_output("JS failed.")


### PR DESCRIPTION
Use the `hint()` method for JSSyntaxError to get a more useful log, for example:

```
[14:06:07] pkjs> SyntaxError: Unexpected token ;
at pebble-js-app.js:1714:6:
    Pebble.on('ready', (function(event) {
      runner.next();
    });
      ^
[14:06:07] pkjs> JS failed.
```

Depends on https://github.com/pebble/pyv8-prebuilt/pull/1